### PR TITLE
Add support for external ASCII formatting callbacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Configure test CMake
         run: cmake -S test -B build-test
       - name: Compile tests
-        run: cmake --build build-test
+        run: cmake --build build-test -j 4
       - name: Run tests
         run: build-test/ufbxw_test --verbose
   ci_cpp:

--- a/extra/ufbxw_fmtlib.h
+++ b/extra/ufbxw_fmtlib.h
@@ -1,0 +1,165 @@
+#ifndef UFBXW_FMTLIB_H_INCLUDED
+#define UFBXW_FMTLIB_H_INCLUDED
+
+#include <stddef.h>
+
+#if !defined(ufbxw_fmtlib_abi)
+	#if defined(UFBXW_fmtlib_STATIC)
+		#define ufbxw_fmtlib_abi static
+	#else
+		#define ufbxw_fmtlib_abi
+	#endif
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+ufbxw_fmtlib_abi void ufbxw_fmtlib_setup(struct ufbxw_ascii_formatter *formatter);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif
+
+#ifdef UFBXW_FMTLIB_IMPLEMENTATION
+#ifndef UFBXW_FMTLIB_H_IMPLEMENTED
+#define UFBXW_FMTLIB_H_IMPLEMENTED
+
+#if !defined(__cplusplus)
+	#error "ufbxw_fmtlib.h should be implemented in a C++ file, though it can be used in another C file"
+#endif
+
+#if !defined(UFBXW_VERSION)
+	#error "Please include ufbx_write.h before implementing ufbxw_fmtlib.h"
+#endif
+
+#if !defined(FMT_VERSION)
+	#error "Please include fmt/format.h before implementing ufbxw_fmtlib.h"
+#endif
+
+#if defined(FMT_COMPILE)
+	#define UFBXWI_FMT(fmt) FMT_COMPILE(fmt)
+#else
+	#define UFBXWI_FMT(fmt) fmt
+#endif
+
+static size_t ufbxw_fmtlib_format_int(void *user, char *dst, size_t dst_size, const int32_t *src, size_t src_count)
+{
+	char *d = dst;
+
+	while (src_count >= 4) {
+		d = fmt::format_to(d, UFBXWI_FMT("{},{},{},{},"), src[0], src[1], src[2], src[3]);
+		src += 4;
+		src_count -= 4;
+	}
+	while (src_count > 0) {
+		d = fmt::format_to(d, UFBXWI_FMT("{},"), src[0]);
+		src += 1;
+		src_count -= 1;
+	}
+
+	return (size_t)(d - dst);
+}
+
+static size_t ufbxw_fmtlib_format_long(void *user, char *dst, size_t dst_size, const int64_t *src, size_t src_count)
+{
+	char *d = dst;
+
+	while (src_count >= 4) {
+		d = fmt::format_to(d, UFBXWI_FMT("{},{},{},{},"), src[0], src[1], src[2], src[3]);
+		src += 4;
+		src_count -= 4;
+	}
+	while (src_count > 0) {
+		d = fmt::format_to(d, UFBXWI_FMT("{},"), src[0]);
+		src += 1;
+		src_count -= 1;
+	}
+
+	return (size_t)(d - dst);
+}
+
+static size_t ufbxw_fmtlib_format_float(void *user, char *dst, size_t dst_size, const float *src, size_t src_count, ufbxw_ascii_float_format format)
+{
+	char *d = dst;
+
+	if (format == UFBXW_ASCII_FLOAT_FORMAT_FIXED_PRECISION) {
+		while (src_count >= 4) {
+			d = fmt::format_to(d, UFBXWI_FMT("{:.7g},{:.7g},{:.7g},{:.7g},"), src[0], src[1], src[2], src[3]);
+			src += 4;
+			src_count -= 4;
+		}
+		while (src_count > 0) {
+			d = fmt::format_to(d, UFBXWI_FMT("{:.7g},"), src[0]);
+			src += 1;
+			src_count -= 1;
+		}
+	} else if (format == UFBXW_ASCII_FLOAT_FORMAT_ROUND_TRIP) {
+		while (src_count >= 4) {
+			d = fmt::format_to(d, UFBXWI_FMT("{:g},{:g},{:g},{:g},"), src[0], src[1], src[2], src[3]);
+			src += 4;
+			src_count -= 4;
+		}
+		while (src_count > 0) {
+			d = fmt::format_to(d, UFBXWI_FMT("{:g},"), src[0]);
+			src += 1;
+			src_count -= 1;
+		}
+	}
+
+	return (size_t)(d - dst);
+}
+
+static size_t ufbxw_fmtlib_format_double(void *user, char *dst, size_t dst_size, const double *src, size_t src_count, ufbxw_ascii_float_format format)
+{
+	char *d = dst;
+
+	if (format == UFBXW_ASCII_FLOAT_FORMAT_FIXED_PRECISION) {
+		while (src_count >= 4) {
+			d = fmt::format_to(d, UFBXWI_FMT("{:.16g},{:.16g},{:.16g},{:.16g},"), src[0], src[1], src[2], src[3]);
+			src += 4;
+			src_count -= 4;
+		}
+		while (src_count > 0) {
+			d = fmt::format_to(d, UFBXWI_FMT("{:.16g},"), src[0]);
+			src += 1;
+			src_count -= 1;
+		}
+	} else if (format == UFBXW_ASCII_FLOAT_FORMAT_ROUND_TRIP) {
+		while (src_count >= 4) {
+			d = fmt::format_to(d, UFBXWI_FMT("{:g},{:g},{:g},{:g},"), src[0], src[1], src[2], src[3]);
+			src += 4;
+			src_count -= 4;
+		}
+		while (src_count > 0) {
+			d = fmt::format_to(d, UFBXWI_FMT("{:g},"), src[0]);
+			src += 1;
+			src_count -= 1;
+		}
+	}
+
+	return (size_t)(d - dst);
+}
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+ufbxw_fmtlib_abi void ufbxw_fmtlib_setup(struct ufbxw_ascii_formatter *formatter)
+{
+	formatter->format_int_fn = &ufbxw_fmtlib_format_int;
+	formatter->format_long_fn = &ufbxw_fmtlib_format_long;
+	formatter->format_float_fn = &ufbxw_fmtlib_format_float;
+	formatter->format_double_fn = &ufbxw_fmtlib_format_double;
+	formatter->user = nullptr;
+}
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif
+#endif
+

--- a/extra/ufbxw_fmtlib.h
+++ b/extra/ufbxw_fmtlib.h
@@ -4,7 +4,7 @@
 #include <stddef.h>
 
 #if !defined(ufbxw_fmtlib_abi)
-	#if defined(UFBXW_fmtlib_STATIC)
+	#if defined(UFBXW_FMTLIB_STATIC)
 		#define ufbxw_fmtlib_abi static
 	#else
 		#define ufbxw_fmtlib_abi

--- a/extra/ufbxw_libdeflate.h
+++ b/extra/ufbxw_libdeflate.h
@@ -24,7 +24,15 @@ typedef struct ufbxw_libdeflate_opts {
 	ufbxw_libdeflate_allocator allocator;
 } ufbxw_libdeflate_opts;
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 ufbxw_libdeflate_abi void ufbxw_libdeflate_setup(struct ufbxw_deflate *deflate, const ufbxw_libdeflate_opts *opts);
+
+#if defined(__cplusplus)
+}
+#endif
 
 #endif
 
@@ -86,6 +94,10 @@ static bool ufbxw_libdeflate_init(void *user, ufbxw_deflate_compressor *compress
 	return true;
 }
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 ufbxw_libdeflate_abi void ufbxw_libdeflate_setup(struct ufbxw_deflate *deflate, const ufbxw_libdeflate_opts *opts)
 {
 	deflate->create_cb.fn = &ufbxw_libdeflate_init;
@@ -93,6 +105,10 @@ ufbxw_libdeflate_abi void ufbxw_libdeflate_setup(struct ufbxw_deflate *deflate, 
 	deflate->streaming_input = false;
 	deflate->streaming_output = false;
 }
+
+#if defined(__cplusplus)
+}
+#endif
 
 #endif
 #endif

--- a/extra/ufbxw_to_chars.h
+++ b/extra/ufbxw_to_chars.h
@@ -1,0 +1,122 @@
+#ifndef UFBXW_TO_CHARS_H_INCLUDED
+#define UFBXW_TO_CHARS_H_INCLUDED
+
+#include <stddef.h>
+
+#if !defined(ufbxw_to_chars_abi)
+	#if defined(UFBXW_to_chars_STATIC)
+		#define ufbxw_to_chars_abi static
+	#else
+		#define ufbxw_to_chars_abi
+	#endif
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+ufbxw_to_chars_abi void ufbxw_to_chars_setup(struct ufbxw_ascii_formatter *formatter);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif
+
+#ifdef UFBXW_TO_CHARS_IMPLEMENTATION
+#ifndef UFBXW_TO_CHARS_H_IMPLEMENTED
+#define UFBXW_TO_CHARS_H_IMPLEMENTED
+
+#if !defined(__cplusplus)
+	#error "ufbxw_to_chars.h should be implemented in a C++ file, though it can be used in another C file"
+#endif
+
+#if !defined(UFBXW_VERSION)
+	#error "Please include ufbx_write.h before implementing ufbxw_to_chars.h"
+#endif
+
+#include <charconv>
+
+static size_t ufbxw_to_chars_format_int(void *user, char *dst, size_t dst_size, const int32_t *src, size_t src_count)
+{
+	char *d = dst, *end = dst + dst_size;
+
+	for (size_t i = 0; i < src_count; i++) {
+		d = std::to_chars(d, end, src[i]).ptr;
+		*d++ = ',';
+	}
+
+	return (size_t)(d - dst);
+}
+
+static size_t ufbxw_to_chars_format_long(void *user, char *dst, size_t dst_size, const int64_t *src, size_t src_count)
+{
+	char *d = dst, *end = dst + dst_size;
+
+	for (size_t i = 0; i < src_count; i++) {
+		d = std::to_chars(d, end, src[i]).ptr;
+		*d++ = ',';
+	}
+
+	return (size_t)(d - dst);
+}
+
+static size_t ufbxw_to_chars_format_float(void *user, char *dst, size_t dst_size, const float *src, size_t src_count, ufbxw_ascii_float_format format)
+{
+	char *d = dst, *end = dst + dst_size;
+
+	if (format == UFBXW_ASCII_FLOAT_FORMAT_FIXED_PRECISION) {
+		for (size_t i = 0; i < src_count; i++) {
+			d = std::to_chars(d, end, src[i], std::chars_format::general, 7).ptr;
+			*d++ = ',';
+		}
+	} else if (format == UFBXW_ASCII_FLOAT_FORMAT_ROUND_TRIP) {
+		for (size_t i = 0; i < src_count; i++) {
+			d = std::to_chars(d, end, src[i]).ptr;
+			*d++ = ',';
+		}
+	}
+
+	return (size_t)(d - dst);
+}
+
+static size_t ufbxw_to_chars_format_double(void *user, char *dst, size_t dst_size, const double *src, size_t src_count, ufbxw_ascii_float_format format)
+{
+	char *d = dst, *end = dst + dst_size;
+
+	if (format == UFBXW_ASCII_FLOAT_FORMAT_FIXED_PRECISION) {
+		for (size_t i = 0; i < src_count; i++) {
+			d = std::to_chars(d, end, src[i], std::chars_format::general, 15).ptr;
+			*d++ = ',';
+		}
+	} else if (format == UFBXW_ASCII_FLOAT_FORMAT_ROUND_TRIP) {
+		for (size_t i = 0; i < src_count; i++) {
+			d = std::to_chars(d, end, src[i]).ptr;
+			*d++ = ',';
+		}
+	}
+
+	return (size_t)(d - dst);
+}
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+ufbxw_to_chars_abi void ufbxw_to_chars_setup(struct ufbxw_ascii_formatter *formatter)
+{
+	formatter->format_int_fn = &ufbxw_to_chars_format_int;
+	formatter->format_long_fn = &ufbxw_to_chars_format_long;
+	formatter->format_float_fn = &ufbxw_to_chars_format_float;
+	formatter->format_double_fn = &ufbxw_to_chars_format_double;
+	formatter->user = nullptr;
+}
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif
+#endif
+
+

--- a/extra/ufbxw_to_chars.h
+++ b/extra/ufbxw_to_chars.h
@@ -4,7 +4,7 @@
 #include <stddef.h>
 
 #if !defined(ufbxw_to_chars_abi)
-	#if defined(UFBXW_to_chars_STATIC)
+	#if defined(UFBXW_TO_CHARS_STATIC)
 		#define ufbxw_to_chars_abi static
 	#else
 		#define ufbxw_to_chars_abi

--- a/extra/ufbxw_zlib.h
+++ b/extra/ufbxw_zlib.h
@@ -2,7 +2,7 @@
 #define UFBXW_ZLIB_H_INCLUDED
 
 #if !defined(ufbxw_zlib_abi)
-	#if defined(UFBXW_zlib_STATIC)
+	#if defined(UFBXW_ZLIB_STATIC)
 		#define ufbxw_zlib_abi static
 	#else
 		#define ufbxw_zlib_abi

--- a/extra/ufbxw_zlib.h
+++ b/extra/ufbxw_zlib.h
@@ -22,7 +22,15 @@ typedef struct ufbxw_zlib_opts {
 	ufbxw_zlib_allocator allocator;
 } ufbxw_zlib_opts;
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 ufbxw_zlib_abi void ufbxw_zlib_setup(struct ufbxw_deflate *deflate, const ufbxw_zlib_opts *opts);
+
+#if defined(__cplusplus)
+}
+#endif
 
 #endif
 
@@ -111,6 +119,10 @@ static bool ufbxw_zlib_init(void *user, ufbxw_deflate_compressor *compressor, in
 	return true;
 }
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 ufbxw_zlib_abi void ufbxw_zlib_setup(struct ufbxw_deflate *deflate, const ufbxw_zlib_opts *opts)
 {
 	deflate->create_cb.fn = &ufbxw_zlib_init;
@@ -118,6 +130,10 @@ ufbxw_zlib_abi void ufbxw_zlib_setup(struct ufbxw_deflate *deflate, const ufbxw_
 	deflate->streaming_input = true;
 	deflate->streaming_output = true;
 }
+
+#if defined(__cplusplus)
+}
+#endif
 
 #endif
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,8 @@ add_executable(ufbxw_test)
 
 option(USE_LIBDEFLATE "Enable libdeflate" ON)
 option(USE_ZLIB "Enable Zlib" ON)
+option(USE_FMTLIB "Enable fmtlib" ON)
+option(USE_TO_CHARS "Enable to_chars" ON)
 
 set(SRC_EXTRA "")
 
@@ -27,7 +29,7 @@ if(USE_LIBDEFLATE)
     target_link_libraries(ufbxw_test PRIVATE libdeflate_static)
     target_compile_definitions(ufbxw_test PRIVATE UFBXWT_HAS_LIBDEFLATE=1)
 
-    list(APPEND SRC_EXTRA "../extra/ufbxw_libdeflate.h")
+    list(APPEND SRC_EXTRA "../extra/ufbxw_libdeflate.h" "extra/ufbxw_libdeflate.c")
 endif()
 
 if(USE_ZLIB)
@@ -48,7 +50,28 @@ if(USE_ZLIB)
     target_link_libraries(ufbxw_test PRIVATE zlibstatic)
     target_compile_definitions(ufbxw_test PRIVATE UFBXWT_HAS_ZLIB=1)
 
-    list(APPEND SRC_EXTRA "../extra/ufbxw_zlib.h")
+    list(APPEND SRC_EXTRA "../extra/ufbxw_zlib.h" "extra/ufbxw_zlib.c")
+endif()
+
+if(USE_FMTLIB)
+    FetchContent_Declare(
+        fmtlib
+        GIT_REPOSITORY "https://github.com/fmtlib/fmt"
+        EXCLUDE_FROM_ALL
+    )
+
+    FetchContent_MakeAvailable(fmtlib)
+
+    target_link_libraries(ufbxw_test PRIVATE fmt)
+    target_compile_definitions(ufbxw_test PRIVATE UFBXWT_HAS_FMTLIB=1)
+
+    list(APPEND SRC_EXTRA "../extra/ufbxw_fmtlib.h" "extra/ufbxw_fmtlib.cpp")
+endif()
+
+if(USE_TO_CHARS)
+    target_compile_definitions(ufbxw_test PRIVATE UFBXWT_HAS_TO_CHARS=1)
+
+    list(APPEND SRC_EXTRA "../extra/ufbxw_to_chars.h" "extra/ufbxw_to_chars.cpp")
 endif()
 
 set(SRC_UFBX_WRITE
@@ -83,6 +106,8 @@ endif()
 target_compile_definitions(ufbxw_test PRIVATE UFBXW_DEV=1 UFBX_DEV=1)
 
 get_filename_component(ROOT_PATH "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
+
+set_property(TARGET ufbxw_test PROPERTY CXX_STANDARD 17)
 
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT ufbxw_test)
 set_target_properties(ufbxw_test PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY ${ROOT_PATH})

--- a/test/all_tests.h
+++ b/test/all_tests.h
@@ -8,4 +8,4 @@
 #include "test_light.h"
 #include "test_camera.h"
 #include "test_deflate.h"
-
+#include "test_ascii.h"

--- a/test/extra/ufbxw_fmtlib.cpp
+++ b/test/extra/ufbxw_fmtlib.cpp
@@ -1,0 +1,12 @@
+#include "../../ufbx_write.h"
+
+#include "fmt/format.h"
+#if defined(_MSC_VER) && _MSVC_LANG >= 201703L
+	#include "fmt/compile.h"
+#elif __cplusplus >= 201703L
+	#include "fmt/compile.h"
+#endif
+
+#define UFBXW_FMTLIB_IMPLEMENTATION
+#include "../../extra/ufbxw_fmtlib.h"
+

--- a/test/extra/ufbxw_libdeflate.c
+++ b/test/extra/ufbxw_libdeflate.c
@@ -1,0 +1,6 @@
+#include "../../ufbx_write.h"
+
+#include "libdeflate.h"
+
+#define UFBXW_LIBDEFLATE_IMPLEMENTATION
+#include "../../extra/ufbxw_libdeflate.h"

--- a/test/extra/ufbxw_to_chars.cpp
+++ b/test/extra/ufbxw_to_chars.cpp
@@ -1,0 +1,4 @@
+#include "../../ufbx_write.h"
+
+#define UFBXW_TO_CHARS_IMPLEMENTATION
+#include "../../extra/ufbxw_to_chars.h"

--- a/test/extra/ufbxw_zlib.c
+++ b/test/extra/ufbxw_zlib.c
@@ -1,0 +1,6 @@
+#include "../../ufbx_write.h"
+
+#include "zlib.h"
+
+#define UFBXW_ZLIB_IMPLEMENTATION
+#include "../../extra/ufbxw_zlib.h"

--- a/test/runner.c
+++ b/test/runner.c
@@ -16,17 +16,19 @@ static void ufbxwt_assert_fail(const char *file, uint32_t line, const char *expr
 #include "ufbx/ufbx.h"
 
 #ifdef UFBXWT_HAS_LIBDEFLATE
-	#include "libdeflate.h"
-
-	#define UFBXW_LIBDEFLATE_IMPLEMENTATION
 	#include "../extra/ufbxw_libdeflate.h"
 #endif
 
 #ifdef UFBXWT_HAS_ZLIB
-	#include "zlib.h"
-
-	#define UFBXW_ZLIB_IMPLEMENTATION
 	#include "../extra/ufbxw_zlib.h"
+#endif
+
+#ifdef UFBXWT_HAS_FMTLIB
+	#include "../extra/ufbxw_fmtlib.h"
+#endif
+
+#ifdef UFBXWT_HAS_TO_CHARS
+	#include "../extra/ufbxw_to_chars.h"
 #endif
 
 #define ufbxwt_arraycount(arr) (sizeof(arr) / sizeof(*(arr)))

--- a/test/runner.c
+++ b/test/runner.c
@@ -186,8 +186,20 @@ typedef enum {
 	UFBXWT_DEFLATE_IMPL_COUNT,
 } ufbxwt_deflate_impl;
 
-bool ufbxwt_deflate_setup(struct ufbxw_deflate *deflate, ufbxwt_deflate_impl impl);
+typedef enum {
+	UFBXWT_ASCII_FORMAT_IMPL_DEFAULT,
+	UFBXWT_ASCII_FORMAT_IMPL_FMTLIB,
+	UFBXWT_ASCII_FORMAT_IMPL_TO_CHARS,
+
+	UFBXWT_ASCII_FORMAT_IMPL_COUNT,
+} ufbxwt_ascii_format_impl;
+
+bool ufbxwt_deflate_setup(ufbxw_deflate *deflate, ufbxwt_deflate_impl impl);
 const char *ufbxwt_deflate_impl_name(ufbxwt_deflate_impl impl);
+
+bool ufbxwt_ascii_format_setup(ufbxw_ascii_formatter *formatter, ufbxwt_ascii_format_impl impl);
+const char *ufbxwt_ascii_format_name(ufbxwt_ascii_format_impl impl);
+
 bool ufbxwt_check_scene_error_imp(ufbxw_scene *scene, const char *file, int line);
 void ufbxwt_do_scene_test(const char *name, void (*test_fn)(ufbxw_scene *scene, ufbxwt_diff_error *err), void (*check_fn)(ufbx_scene *scene, ufbxwt_diff_error *err), const ufbxw_scene_opts *user_opts, uint32_t flags);
 
@@ -307,7 +319,7 @@ static void ufbxwt_error_callback(void *user, const ufbxw_error *error)
 	ufbxwt_assert(0 && "error");
 }
 
-bool ufbxwt_deflate_setup(struct ufbxw_deflate *deflate, ufbxwt_deflate_impl impl)
+bool ufbxwt_deflate_setup(ufbxw_deflate *deflate, ufbxwt_deflate_impl impl)
 {
 	switch (impl) {
 	case UFBXWT_DEFLATE_IMPL_NONE:
@@ -340,6 +352,43 @@ const char *ufbxwt_deflate_impl_name(ufbxwt_deflate_impl impl)
 	case UFBXWT_DEFLATE_IMPL_NONE: return "none";
 	case UFBXWT_DEFLATE_IMPL_LIBDEFLATE: return "libdeflate";
 	case UFBXWT_DEFLATE_IMPL_ZLIB: return "zlib";
+	default: return "";
+	}
+}
+
+bool ufbxwt_ascii_format_setup(ufbxw_ascii_formatter *formatter, ufbxwt_ascii_format_impl impl)
+{
+	switch (impl) {
+	case UFBXWT_ASCII_FORMAT_IMPL_DEFAULT:
+		return true;
+
+	case UFBXWT_ASCII_FORMAT_IMPL_FMTLIB:
+		#if UFBXWT_HAS_FMTLIB
+			ufbxw_fmtlib_setup(formatter);
+			return true;
+		#endif
+		return false;
+
+	case UFBXWT_ASCII_FORMAT_IMPL_TO_CHARS:
+		#if UFBXWT_HAS_TO_CHARS
+			ufbxw_to_chars_setup(formatter);
+			return true;
+		#endif
+		return false;
+
+	default:
+		ufbxwt_assert(false);
+		break;
+	}
+	return false;
+}
+
+const char *ufbxwt_ascii_format_name(ufbxwt_ascii_format_impl impl)
+{
+	switch (impl) {
+	case UFBXWT_ASCII_FORMAT_IMPL_DEFAULT: return "default";
+	case UFBXWT_ASCII_FORMAT_IMPL_FMTLIB: return "fmtlib";
+	case UFBXWT_ASCII_FORMAT_IMPL_TO_CHARS: return "to_chars";
 	default: return "";
 	}
 }

--- a/test/test_ascii.h
+++ b/test/test_ascii.h
@@ -1,0 +1,93 @@
+#undef UFBXWT_TEST_GROUP
+#define UFBXWT_TEST_GROUP "ascii"
+
+#if UFBXWT_IMPL
+
+static void ufbxwt_ascii_format_test(const char *name, ufbxw_scene *scene, const ufbxw_save_opts *opts, size_t result_size)
+{
+	static const uint32_t versions[] = { 7400, 7500 };
+
+	void *result = malloc(result_size);
+	ufbxwt_assert(result);
+
+	ufbxwt_memory_stream stream = { result, result_size };
+
+	ufbxw_write_stream ws = { 0 };
+	ws.write_fn = &ufbxwt_memory_stream_write;
+	ws.user = &stream;
+
+	static const ufbxw_save_format formats[] = { UFBXW_SAVE_FORMAT_BINARY, UFBXW_SAVE_FORMAT_ASCII };
+
+	for (int format_ix = 0; format_ix < ufbxwt_arraycount(formats); format_ix++) {
+		for (int ascii_ix = 0; ascii_ix < UFBXWT_ASCII_FORMAT_IMPL_COUNT; ascii_ix++) {
+			for (int float_ix = 0; float_ix < 2; float_ix++) {
+
+				ufbxw_save_opts save_opts = { 0 };
+				if (opts) {
+					save_opts = *opts;
+				}
+
+				save_opts.version = 7500;
+				save_opts.format = formats[format_ix];
+				const char *float_name = "";
+				switch (float_ix) {
+				case 0:
+					save_opts.ascii_float_format = UFBXW_ASCII_FLOAT_FORMAT_FIXED_PRECISION;
+					float_name = "fixed_precision";
+					break;
+				case 1:
+					save_opts.ascii_float_format = UFBXW_ASCII_FLOAT_FORMAT_ROUND_TRIP;
+					float_name = "round_trip";
+					break;
+				}
+
+				ufbxwt_ascii_format_impl ascii_impl = (ufbxwt_ascii_format_impl)ascii_ix;
+				const char *format = save_opts.format == UFBXW_SAVE_FORMAT_ASCII ? "ascii" : "binary";
+
+				if (save_opts.format == UFBXW_SAVE_FORMAT_BINARY && ascii_impl != UFBXWT_ASCII_FORMAT_IMPL_DEFAULT) {
+					continue;
+				}
+
+				if (save_opts.format == UFBXW_SAVE_FORMAT_BINARY && float_ix != 0) {
+					continue;
+				}
+
+				if (!ufbxwt_ascii_format_setup(&save_opts.ascii_formatter, ascii_impl)) {
+					continue;
+				}
+
+				const char *ascii = ufbxwt_ascii_format_name(ascii_impl);
+				ufbxwt_logf("format: %s, version: %u, ascii: %s, float: %s", format, save_opts.version, ascii, float_name);
+
+				memset(result, 0, result_size);
+
+				ufbxw_error save_error;
+				bool save_ok = ufbxw_save_stream(scene, &ws, &save_opts, &save_error);
+				if (save_error.type != UFBXW_ERROR_NONE) {
+					ufbxwt_log_error(&save_error);
+				}
+				ufbxwt_assert(save_ok);
+
+				ufbx_error load_error;
+				ufbx_scene *loaded_scene = ufbx_load_memory(result, result_size, NULL, &load_error);
+				if (load_error.type != UFBX_ERROR_NONE) {
+					ufbxwt_log_uerror(&load_error);
+				}
+				ufbxwt_assert(loaded_scene);
+				ufbx_free_scene(loaded_scene);
+			}
+		}
+	}
+
+	free(result);
+	ufbxw_free_scene(scene);
+}
+
+#endif
+
+UFBXWT_TEST(ascii_format_simple)
+#if UFBXWT_IMPL
+{
+	ufbxwt_ascii_format_test("simple", ufbxwt_deflate_scene_simple(), NULL, 64 * 1024);
+}
+#endif

--- a/test/test_deflate.h
+++ b/test/test_deflate.h
@@ -1,3 +1,5 @@
+#undef UFBXWT_TEST_GROUP
+#define UFBXWT_TEST_GROUP "deflate"
 
 #if UFBXWT_IMPL
 

--- a/ufbx_write.c
+++ b/ufbx_write.c
@@ -6417,7 +6417,7 @@ static void ufbxwi_ascii_dom_write(ufbxwi_save_context *sc, const char *tag, con
 			size_t src_count = 1;
 			src[0] = va_arg(args, float);
 			for (; pf[1] == 'F' && src_count < 4; src_count++, pf++) {
-				src[src_count] = va_arg(args, float);
+				src[src_count] = (float)va_arg(args, double);
 			}
 			size_t len = sc->opts.ascii_formatter.format_float_fn(sc->opts.ascii_formatter.user, dst, 128, src, src_count, sc->opts.ascii_float_format);
 			ufbxwi_write_commit(sc, (size_t)len - 1);

--- a/ufbx_write.c
+++ b/ufbx_write.c
@@ -6390,28 +6390,48 @@ static void ufbxwi_ascii_dom_write(ufbxwi_save_context *sc, const char *tag, con
 
 		switch (f) {
 		case 'I': {
-			char *dst = ufbxwi_write_reserve_small(sc, 32);
-			int len = snprintf(dst, 32, "%d", va_arg(args, int32_t));
-			ufbxw_assert(len >= 0);
-			ufbxwi_write_commit(sc, (size_t)len);
+			char *dst = ufbxwi_write_reserve_small(sc, 128);
+			int32_t src[4];
+			size_t src_count = 1;
+			src[0] = va_arg(args, int32_t);
+			for (; pf[1] == 'I' && src_count < 4; src_count++, pf++) {
+				src[src_count] = va_arg(args, int32_t);
+			}
+			size_t len = sc->opts.ascii_formatter.format_int_fn(sc->opts.ascii_formatter.user, dst, 128, src, src_count);
+			ufbxwi_write_commit(sc, (size_t)len - 1);
 		} break;
 		case 'L': {
-			char *dst = ufbxwi_write_reserve_small(sc, 32);
-			int len = snprintf(dst, 32, "%lld", (long long)va_arg(args, int64_t));
-			ufbxw_assert(len >= 0);
-			ufbxwi_write_commit(sc, (size_t)len);
+			char *dst = ufbxwi_write_reserve_small(sc, 128);
+			int64_t src[4];
+			size_t src_count = 1;
+			src[0] = va_arg(args, int64_t);
+			for (; pf[1] == 'L' && src_count < 4; src_count++, pf++) {
+				src[src_count] = va_arg(args, int64_t);
+			}
+			size_t len = sc->opts.ascii_formatter.format_long_fn(sc->opts.ascii_formatter.user, dst, 128, src, src_count);
+			ufbxwi_write_commit(sc, (size_t)len - 1);
 		} break;
 		case 'F': {
-			char *dst = ufbxwi_write_reserve_small(sc, 32);
-			int len = snprintf(dst, 32, "%.8g", (float)va_arg(args, double));
-			ufbxw_assert(len >= 0);
-			ufbxwi_write_commit(sc, (size_t)len);
+			char *dst = ufbxwi_write_reserve_small(sc, 128);
+			float src[4];
+			size_t src_count = 1;
+			src[0] = va_arg(args, float);
+			for (; pf[1] == 'F' && src_count < 4; src_count++, pf++) {
+				src[src_count] = va_arg(args, float);
+			}
+			size_t len = sc->opts.ascii_formatter.format_float_fn(sc->opts.ascii_formatter.user, dst, 128, src, src_count, sc->opts.ascii_float_format);
+			ufbxwi_write_commit(sc, (size_t)len - 1);
 		} break;
 		case 'D': {
-			char *dst = ufbxwi_write_reserve_small(sc, 32);
-			int len = snprintf(dst, 32, "%.8g", va_arg(args, double));
-			ufbxw_assert(len >= 0);
-			ufbxwi_write_commit(sc, (size_t)len);
+			char *dst = ufbxwi_write_reserve_small(sc, 128);
+			double src[4];
+			size_t src_count = 1;
+			src[0] = va_arg(args, double);
+			for (; pf[1] == 'D' && src_count < 4; src_count++, pf++) {
+				src[src_count] = va_arg(args, double);
+			}
+			size_t len = sc->opts.ascii_formatter.format_double_fn(sc->opts.ascii_formatter.user, dst, 128, src, src_count, sc->opts.ascii_float_format);
+			ufbxwi_write_commit(sc, (size_t)len - 1);
 		} break;
 		case 'C': {
 			const char *str = va_arg(args, const char*);

--- a/ufbx_write.c
+++ b/ufbx_write.c
@@ -6415,7 +6415,7 @@ static void ufbxwi_ascii_dom_write(ufbxwi_save_context *sc, const char *tag, con
 			char *dst = ufbxwi_write_reserve_small(sc, 128);
 			float src[4];
 			size_t src_count = 1;
-			src[0] = va_arg(args, float);
+			src[0] = (float)va_arg(args, double);
 			for (; pf[1] == 'F' && src_count < 4; src_count++, pf++) {
 				src[src_count] = (float)va_arg(args, double);
 			}

--- a/ufbx_write.c
+++ b/ufbx_write.c
@@ -6278,6 +6278,56 @@ static ufbxwi_forceinline void ufbxwi_write_commit(ufbxwi_save_context *sc, size
 
 // -- ASCII
 
+static size_t ufbxwi_default_ascii_format_int(void *user, char *dst, size_t dst_size, const int32_t *src, size_t src_count)
+{
+	char *d = dst, *end = dst + dst_size;
+	for (size_t i = 0; i < src_count; i++) {
+		d += snprintf(d, ufbxwi_to_size(end - d), "%d,", (int)src[i]);
+	}
+	return ufbxwi_to_size(d - dst);
+}
+
+static size_t ufbxwi_default_ascii_format_long(void *user, char *dst, size_t dst_size, const int64_t *src, size_t src_count)
+{
+	char *d = dst, *end = dst + dst_size;
+	for (size_t i = 0; i < src_count; i++) {
+		d += snprintf(d, ufbxwi_to_size(end - d), "%lld,", (long long)src[i]);
+	}
+	return ufbxwi_to_size(d - dst);
+}
+
+static size_t ufbxwi_default_ascii_format_float(void *user, char *dst, size_t dst_size, const float *src, size_t src_count, ufbxw_ascii_float_format format)
+{
+	const char *fmt = "";
+	switch (format) {
+	case UFBXW_ASCII_FLOAT_FORMAT_FIXED_PRECISION: fmt = "%.7g,"; break;
+	case UFBXW_ASCII_FLOAT_FORMAT_ROUND_TRIP: fmt = "%.9g,"; break;
+	default: return 0;
+	}
+
+	char *d = dst, *end = dst + dst_size;
+	for (size_t i = 0; i < src_count; i++) {
+		d += snprintf(d, ufbxwi_to_size(end - d), fmt, src[i]);
+	}
+	return ufbxwi_to_size(d - dst);
+}
+
+static size_t ufbxwi_default_ascii_format_double(void *user, char *dst, size_t dst_size, const double *src, size_t src_count, ufbxw_ascii_float_format format)
+{
+	const char *fmt = "";
+	switch (format) {
+	case UFBXW_ASCII_FLOAT_FORMAT_FIXED_PRECISION: fmt = "%.15g,"; break;
+	case UFBXW_ASCII_FLOAT_FORMAT_ROUND_TRIP: fmt = "%.17g,"; break;
+	default: return 0;
+	}
+
+	char *d = dst, *end = dst + dst_size;
+	for (size_t i = 0; i < src_count; i++) {
+		d += snprintf(d, ufbxwi_to_size(end - d), fmt, src[i]);
+	}
+	return ufbxwi_to_size(d - dst);
+}
+
 static void ufbxwi_ascii_indent(ufbxwi_save_context *sc)
 {
 	size_t indent = ufbxwi_min_sz(sc->depth, 64);
@@ -6391,199 +6441,77 @@ static void ufbxwi_ascii_dom_write(ufbxwi_save_context *sc, const char *tag, con
 	ufbxwi_write(sc, "\n", 1);
 }
 
-static void ufbxwi_ascii_dom_write_int_array(ufbxwi_save_context *sc, ufbxwi_buffer *buffer)
+#define UFBXWI_ASCII_LINE_MAX_SCALARS 128
+
+typedef union {
+	int32_t data_int[UFBXWI_ASCII_LINE_MAX_SCALARS];
+	int64_t data_long[UFBXWI_ASCII_LINE_MAX_SCALARS];
+	float data_float[UFBXWI_ASCII_LINE_MAX_SCALARS];
+	double data_double[UFBXWI_ASCII_LINE_MAX_SCALARS];
+} ufbxwi_line_buffer;
+
+static ufbxwi_noinline void ufbxwi_ascii_dom_write_array_data(ufbxwi_save_context *sc, ufbxwi_buffer *buffer, ufbxwi_buffer_type scalar_type)
 {
 	ufbxwi_buffer_type type = ufbxwi_buffer_id_type(buffer->id);
 	ufbxwi_buffer_type_info type_info = ufbxwi_buffer_type_infos[type];
-	size_t scalar_count = buffer->count * type_info.components;
 
-	if (scalar_count == 0) {
-		ufbxwi_write(sc, "\n", 1);
-		return;
-	}
+	ufbxwi_line_buffer line_temp_buffer;
 
-	int32_t temp[128];
-	size_t temp_size = sizeof(temp);
+	size_t line_elems = UFBXWI_ASCII_LINE_MAX_SCALARS / type_info.components;
+	size_t line_scalars = line_elems * type_info.components;
+
+	size_t scalar_size = ufbxwi_buffer_type_infos[scalar_type].size;
+
+	size_t scalars_left = buffer->count * type_info.components;
+
 	size_t offset = 0;
-
-	size_t line_count = temp_size / sizeof(int32_t);
-	char fmt_buffer[64];
-
 	while (offset < buffer->count) {
 		size_t max_read_size = (buffer->count - offset) * type_info.size;
-		size_t read_size = ufbxwi_min_sz(max_read_size, temp_size);
-		ufbxwi_void_span span = ufbxwi_buffer_read(&sc->buffers, buffer->id, temp, read_size, offset);
-		size_t span_count = span.count * type_info.components;
+		size_t read_size = ufbxwi_min_sz(max_read_size, line_elems);
+		ufbxwi_void_span span = ufbxwi_buffer_read(&sc->buffers, buffer->id, &line_temp_buffer, read_size, offset);
+		size_t span_scalars = span.count * type_info.components;
 
-		for (size_t begin = 0; begin < span_count; ) {
-			size_t count = ufbxwi_min_sz(span_count - begin, line_count);
-			const int32_t *src = (const int32_t*)span.data + begin;
-			size_t pre_comma_count = count - 1;
+		for (size_t begin = 0; begin < span_scalars; ) {
+			size_t src_count = ufbxwi_min_sz(span_scalars - begin, line_scalars);
+			const void *src = (const char*)span.data + begin * scalar_size;
 
-			for (size_t i = 0; i < pre_comma_count; i++) {
-				// TODO: Fast int printing
-				int len = snprintf(fmt_buffer, sizeof(fmt_buffer), "%d,", src[i]);
-				ufbxwi_write(sc, fmt_buffer, (size_t)len);
+			size_t dst_size = src_count * 28 + 1;
+			ufbxwi_mutable_void_span dst_span = ufbxwi_write_reserve_at_least(sc, dst_size);
+			char *dst = (char*)dst_span.data;
+			ufbxwi_check(dst);
+
+			size_t result_length = 0;
+			switch (scalar_type) {
+			case UFBXWI_BUFFER_TYPE_INT:
+				result_length = sc->opts.ascii_formatter.format_int_fn(sc->opts.ascii_formatter.user, dst, dst_size, (const int32_t*)src, src_count);
+				break;
+			case UFBXWI_BUFFER_TYPE_LONG:
+				result_length = sc->opts.ascii_formatter.format_long_fn(sc->opts.ascii_formatter.user, dst, dst_size, (const int64_t*)src, src_count);
+				break;
+			case UFBXWI_BUFFER_TYPE_FLOAT:
+				result_length = sc->opts.ascii_formatter.format_float_fn(sc->opts.ascii_formatter.user, dst, dst_size, (const float*)src, src_count, sc->opts.ascii_float_format);
+				break;
+			case UFBXWI_BUFFER_TYPE_REAL: // TODO: real=float
+				result_length = sc->opts.ascii_formatter.format_double_fn(sc->opts.ascii_formatter.user, dst, dst_size, (const double*)src, src_count, sc->opts.ascii_float_format);
+				break;
+			default:
+				ufbxwi_unreachable("bad scalar type");
 			}
 
-			{
-				int len = snprintf(fmt_buffer, sizeof(fmt_buffer), "%d", src[pre_comma_count]);
-				ufbxwi_write(sc, fmt_buffer, (size_t)len);
-				if (offset * type_info.components + begin + count == scalar_count) {
-					ufbxwi_write(sc, "\n", 1);
-				} else {
-					ufbxwi_write(sc, ",\n", 2);
-				}
+			if (result_length == 0 || result_length == SIZE_MAX) {
+				ufbxwi_fail(&sc->error, UFBXW_ERROR_ASCII_FORMAT, "failed to format ASCII numbers");
+				return;
 			}
 
-			begin += count;
-		}
+			scalars_left -= src_count;
+			begin += src_count;
 
-		offset += span.count;
-	}
-}
-
-// TODO: Deduplicate these
-static void ufbxwi_ascii_dom_write_long_array(ufbxwi_save_context *sc, ufbxwi_buffer *buffer)
-{
-	ufbxwi_buffer_type type = ufbxwi_buffer_id_type(buffer->id);
-	ufbxwi_buffer_type_info type_info = ufbxwi_buffer_type_infos[type];
-	size_t scalar_count = buffer->count * type_info.components;
-
-	if (scalar_count == 0) {
-		ufbxwi_write(sc, "\n", 1);
-		return;
-	}
-
-	int64_t temp[128];
-	size_t temp_size = sizeof(temp);
-	size_t offset = 0;
-
-	size_t line_count = temp_size / sizeof(int64_t);
-	char fmt_buffer[64];
-
-	while (offset < buffer->count) {
-		size_t max_read_size = (buffer->count - offset) * type_info.size;
-		size_t read_size = ufbxwi_min_sz(max_read_size, temp_size);
-		ufbxwi_void_span span = ufbxwi_buffer_read(&sc->buffers, buffer->id, temp, read_size, offset);
-		size_t span_count = span.count * type_info.components;
-
-		for (size_t begin = 0; begin < span_count; ) {
-			size_t count = ufbxwi_min_sz(span_count - begin, line_count);
-			const int64_t *src = (const int64_t*)span.data + begin;
-			size_t pre_comma_count = count - 1;
-
-			for (size_t i = 0; i < pre_comma_count; i++) {
-				// TODO: Fast int printing
-				int len = snprintf(fmt_buffer, sizeof(fmt_buffer), "%lld,", (long long)src[i]);
-				ufbxwi_write(sc, fmt_buffer, (size_t)len);
+			if (scalars_left == 0) {
+				dst[result_length - 1] = '\n';
+			} else {
+				dst[result_length++] = '\n';
 			}
-
-			{
-				int len = snprintf(fmt_buffer, sizeof(fmt_buffer), "%lld", (long long)src[pre_comma_count]);
-				ufbxwi_write(sc, fmt_buffer, (size_t)len);
-				if (offset * type_info.components + begin + count == scalar_count) {
-					ufbxwi_write(sc, "\n", 1);
-				} else {
-					ufbxwi_write(sc, ",\n", 2);
-				}
-			}
-
-			begin += count;
-		}
-
-		offset += span.count;
-	}
-}
-
-static void ufbxwi_ascii_dom_write_real_array(ufbxwi_save_context *sc, ufbxwi_buffer *buffer)
-{
-	ufbxwi_buffer_type type = ufbxwi_buffer_id_type(buffer->id);
-	ufbxwi_buffer_type_info type_info = ufbxwi_buffer_type_infos[type];
-	size_t scalar_count = buffer->count * type_info.components;
-
-	ufbxw_real temp[128];
-	size_t temp_size = sizeof(temp);
-	size_t offset = 0;
-
-	size_t line_count = temp_size / sizeof(ufbxw_real);
-	char fmt_buffer[64];
-
-	while (offset < buffer->count) {
-		size_t max_read_size = (buffer->count - offset) * type_info.size;
-		size_t read_size = ufbxwi_min_sz(max_read_size, temp_size);
-		ufbxwi_void_span span = ufbxwi_buffer_read(&sc->buffers, buffer->id, temp, read_size, offset);
-		size_t span_count = span.count * type_info.components;
-
-		for (size_t begin = 0; begin < span_count; ) {
-			size_t count = ufbxwi_min_sz(span_count - begin, line_count);
-			const ufbxw_real *src = (const ufbxw_real*)span.data + begin;
-			size_t pre_comma_count = count - 1;
-
-			for (size_t i = 0; i < pre_comma_count; i++) {
-				// TODO: Fast float printing
-				int len = snprintf(fmt_buffer, sizeof(fmt_buffer), "%.15g,", src[i]);
-				ufbxwi_write(sc, fmt_buffer, (size_t)len);
-			}
-
-			{
-				int len = snprintf(fmt_buffer, sizeof(fmt_buffer), "%.15g", src[pre_comma_count]);
-				ufbxwi_write(sc, fmt_buffer, (size_t)len);
-				if (offset * type_info.components + begin + count == scalar_count) {
-					ufbxwi_write(sc, "\n", 1);
-				} else {
-					ufbxwi_write(sc, ",\n", 2);
-				}
-			}
-
-			begin += count;
-		}
-
-		offset += span.count;
-	}
-}
-
-static void ufbxwi_ascii_dom_write_float_array(ufbxwi_save_context *sc, ufbxwi_buffer *buffer)
-{
-	ufbxwi_buffer_type type = ufbxwi_buffer_id_type(buffer->id);
-	ufbxwi_buffer_type_info type_info = ufbxwi_buffer_type_infos[type];
-	size_t scalar_count = buffer->count * type_info.components;
-
-	float temp[128];
-	size_t temp_size = sizeof(temp);
-	size_t offset = 0;
-
-	size_t line_count = temp_size / sizeof(float);
-	char fmt_buffer[64];
-
-	while (offset < buffer->count) {
-		size_t max_read_size = (buffer->count - offset) * type_info.size;
-		size_t read_size = ufbxwi_min_sz(max_read_size, temp_size);
-		ufbxwi_void_span span = ufbxwi_buffer_read(&sc->buffers, buffer->id, temp, read_size, offset);
-		size_t span_count = span.count * type_info.components;
-
-		for (size_t begin = 0; begin < span_count; ) {
-			size_t count = ufbxwi_min_sz(span_count - begin, line_count);
-			const float *src = (const float*)span.data + begin;
-			size_t pre_comma_count = count - 1;
-
-			for (size_t i = 0; i < pre_comma_count; i++) {
-				// TODO: Fast float printing
-				int len = snprintf(fmt_buffer, sizeof(fmt_buffer), "%.7g,", src[i]);
-				ufbxwi_write(sc, fmt_buffer, (size_t)len);
-			}
-
-			{
-				int len = snprintf(fmt_buffer, sizeof(fmt_buffer), "%.7g", src[pre_comma_count]);
-				ufbxwi_write(sc, fmt_buffer, (size_t)len);
-				if (offset * type_info.components + begin + count == scalar_count) {
-					ufbxwi_write(sc, "\n", 1);
-				} else {
-					ufbxwi_write(sc, ",\n", 2);
-				}
-			}
-
-			begin += count;
+			ufbxwi_write_commit(sc, result_length);
 		}
 
 		offset += span.count;
@@ -6618,22 +6546,7 @@ static void ufbxwi_ascii_dom_write_array(ufbxwi_save_context *sc, const char *ta
 		scalar_type = UFBXWI_BUFFER_TYPE_INT;
 	}
 
-	switch (scalar_type) {
-	case UFBXWI_BUFFER_TYPE_INT:
-		ufbxwi_ascii_dom_write_int_array(sc, buffer);
-		break;
-	case UFBXWI_BUFFER_TYPE_LONG:
-		ufbxwi_ascii_dom_write_long_array(sc, buffer);
-		break;
-	case UFBXWI_BUFFER_TYPE_REAL:
-		ufbxwi_ascii_dom_write_real_array(sc, buffer);
-		break;
-	case UFBXWI_BUFFER_TYPE_FLOAT:
-		ufbxwi_ascii_dom_write_float_array(sc, buffer);
-		break;
-	default:
-		ufbxwi_unreachable("bad scalar type");
-	}
+	ufbxwi_ascii_dom_write_array_data(sc, buffer, scalar_type);
 
 	sc->depth--;
 
@@ -8371,6 +8284,19 @@ static void ufbxwi_save_imp(ufbxwi_save_context *sc)
 	size_t buffer_size = 0x10000;
 	if (sc->opts.buffer_size > 0) {
 		buffer_size = ufbxwi_max_sz(sc->opts.buffer_size, 512);
+	}
+
+	if (!sc->opts.ascii_formatter.format_int_fn) {
+		sc->opts.ascii_formatter.format_int_fn = &ufbxwi_default_ascii_format_int;
+	}
+	if (!sc->opts.ascii_formatter.format_long_fn) {
+		sc->opts.ascii_formatter.format_long_fn = &ufbxwi_default_ascii_format_long;
+}
+	if (!sc->opts.ascii_formatter.format_float_fn) {
+		sc->opts.ascii_formatter.format_float_fn = &ufbxwi_default_ascii_format_float;
+	}
+	if (!sc->opts.ascii_formatter.format_double_fn) {
+		sc->opts.ascii_formatter.format_double_fn = &ufbxwi_default_ascii_format_double;
 	}
 
 	// TODO: Make sure buffer fits at least binary header

--- a/ufbx_write.h
+++ b/ufbx_write.h
@@ -309,6 +309,7 @@ typedef enum ufbxw_error_type {
 	UFBXW_ERROR_ARRAY_TOO_BIG,
 	UFBXW_ERROR_PATH_TOO_LONG,
 	UFBXW_ERROR_FILE_OPEN_FAILED,
+	UFBXW_ERROR_ASCII_FORMAT,
 
 } ufbxw_error_type;
 

--- a/ufbx_write.h
+++ b/ufbx_write.h
@@ -1144,6 +1144,32 @@ typedef struct ufbxw_deflate {
 	bool streaming_output;
 } ufbxw_deflate;
 
+// -- ASCII formatting
+
+// TODO: Should round trip be default?
+typedef enum ufbxw_ascii_float_format {
+	// Fixed-precision formatting, matching what the FBX SDK outputs.
+	// Equivalent to printing the floats as `%.15g` (double) and `%.7g` (float)
+	UFBXW_ASCII_FLOAT_FORMAT_FIXED_PRECISION,
+
+	// Print the floats using an implementation-defined method that guarantees round trip.
+	UFBXW_ASCII_FLOAT_FORMAT_ROUND_TRIP,
+
+} ufbxw_ascii_float_format;
+
+typedef size_t ufbxw_ascii_format_int_fn(void *user, char *dst, size_t dst_size, const int32_t *src, size_t src_count);
+typedef size_t ufbxw_ascii_format_long_fn(void *user, char *dst, size_t dst_size, const int64_t *src, size_t src_count);
+typedef size_t ufbxw_ascii_format_float_fn(void *user, char *dst, size_t dst_size, const float *src, size_t src_count, ufbxw_ascii_float_format format);
+typedef size_t ufbxw_ascii_format_double_fn(void *user, char *dst, size_t dst_size, const double *src, size_t src_count, ufbxw_ascii_float_format format);
+
+typedef struct ufbxw_ascii_formatter {
+	ufbxw_ascii_format_int_fn *format_int_fn;
+	ufbxw_ascii_format_long_fn *format_long_fn;
+	ufbxw_ascii_format_float_fn *format_float_fn;
+	ufbxw_ascii_format_double_fn *format_double_fn;
+	void *user;
+} ufbxw_ascii_formatter;
+
 // -- Writing API
 
 typedef enum ufbxw_save_format {
@@ -1159,6 +1185,8 @@ typedef struct ufbxw_save_opts {
 
 	ufbxw_deflate deflate;
 
+	ufbxw_ascii_formatter ascii_formatter;
+
 	ufbxw_allocator allocator;
 
 	// Compression level.
@@ -1168,6 +1196,9 @@ typedef struct ufbxw_save_opts {
 	// Window size to use when doing streaming deflate compression.
 	// Defaults to `64kB`.
 	size_t deflate_window_size;
+
+	// How to format floating point numbers in ASCII files.
+	ufbxw_ascii_float_format ascii_float_format;
 
 	// TODO: Do not save animation
 	bool ignore_animation;


### PR DESCRIPTION
This lets us avoid `printf()` on the hot path.

Currently only implemented with fmtlib and C++17 `std::to_chars()`. For this there should be a fallback implementation using `snprintf()`.

Maybe it should still fail without a specific "allow" flag as with deflate to avoid accidental pessimization.