### PR TITLE
Pass ufbxw_string to ufbxwi_dom_value by value in save_mesh

### DIFF
--- a/ufbx_write.c
+++ b/ufbx_write.c
@@ -8710,7 +8710,7 @@ static void ufbxwi_save_mesh_data(ufbxwi_save_context *sc, ufbxwi_element *eleme
 		ufbxwi_dom_open(sc, info->layer_element_name, "I", attrib->set);
 
 		ufbxwi_dom_value(sc, "Version", "I", info->version);
-		ufbxwi_dom_value(sc, "Name", "S", &attrib->name);
+		ufbxwi_dom_value(sc, "Name", "S", attrib->name);
 		ufbxwi_dom_value(sc, "MappingInformationType", "C", ufbxwi_attribute_mapping_infos[attrib->mapping].name);
 		ufbxwi_dom_value(sc, "ReferenceInformationType", "C", attrib->indices ? "IndexToDirect" : "Direct");
 


### PR DESCRIPTION
Fixes segfault on Mac / invalid write call on Linux when saving meshes (Linux seems to not crash when invalid pointers and lengths are passed to `write()`)

attrib->name was being passed by pointer. You can see that the va_arg call uses the struct type itself, not the pointer, so this must also pass in the struct itself.

I checked and this is the only place matching the regex `ufbxwi_dom_value.*&` so probably there are no other occurrences of this issue.