### PR TITLE
ASCII fatal error handling + Zmij

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,9 @@ jobs:
       - name: Compile tests
         run: cmake --build build-test -j 4
       - name: Run tests
-        run: build-test/test/ufbxw_test --verbose
+        run: build-test/test/ufbxw_test.exe --verbose
       - name: Run unit tests
-        run: build-test/unit/ufbxw_unit --verbose
+        run: build-test/unit/ufbxw_unit.exe --verbose
 
   ci_macos:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,9 @@ jobs:
       - name: Compile tests
         run: cmake --build build-test -j 4
       - name: Run tests
-        run: build-test/test/ufbxw_test.exe --verbose
+        run: build-test\test\Debug\ufbxw_test.exe --verbose
       - name: Run unit tests
-        run: build-test/unit/ufbxw_unit.exe --verbose
+        run: build-test\unit\Debug\ufbxw_unit.exe --verbose
 
   ci_macos:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,36 @@ jobs:
       - name: Run unit tests
         run: build-test/unit/ufbxw_unit --verbose
 
+  ci_windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Configure test CMake
+        run: cmake -S test -B build-test
+      - name: Compile tests
+        run: cmake --build build-test -j 4
+      - name: Run tests
+        run: build-test/test/ufbxw_test --verbose
+      - name: Run unit tests
+        run: build-test/unit/ufbxw_unit --verbose
+
+  ci_macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Configure test CMake
+        run: cmake -S test -B build-test
+      - name: Compile tests
+        run: cmake --build build-test -j 4
+      - name: Run tests
+        run: build-test/test/ufbxw_test --verbose
+      - name: Run unit tests
+        run: build-test/unit/ufbxw_unit --verbose
+
   ci_sanitize:
     runs-on: ubuntu-latest
     steps:

--- a/extra/ufbxw_zmij.h
+++ b/extra/ufbxw_zmij.h
@@ -3,7 +3,7 @@
 
 // Adapter for Zmij C++ implementation, for float/double formatting.
 //
-// https://github.com/dtolnay/zmij
+// https://github.com/vitaut/zmij
 //
 // Only supports floating point formatting with `UFBXW_ASCII_FLOAT_FORMAT_ROUND_TRIP`.
 //

--- a/extra/ufbxw_zmij.h
+++ b/extra/ufbxw_zmij.h
@@ -66,6 +66,9 @@ ufbxw_zmij_abi void ufbxw_zmij_setup(struct ufbxw_ascii_formatter *formatter);
 
 #include <stdint.h>
 
+static_assert(zmij::float_buffer_size <= UFBXW_ASCII_FORMAT_FLOAT_CHARS + UFBXW_ASCII_FORMAT_EXTRA_BUFFER_CHARS, "ufbxw float buffer is too small");
+static_assert(zmij::double_buffer_size <= UFBXW_ASCII_FORMAT_DOUBLE_CHARS + UFBXW_ASCII_FORMAT_EXTRA_BUFFER_CHARS, "ufbxw double buffer is too small");
+
 static size_t ufbxw_zmij_format_float(void *user, char *dst, size_t dst_size, const float *src, size_t src_count, ufbxw_ascii_float_format format)
 {
 	if (format != UFBXW_ASCII_FLOAT_FORMAT_ROUND_TRIP) return SIZE_MAX;

--- a/extra/ufbxw_zmij.h
+++ b/extra/ufbxw_zmij.h
@@ -1,0 +1,108 @@
+#ifndef UFBXW_ZMIJ_H_INCLUDED
+#define UFBXW_ZMIJ_H_INCLUDED
+
+// Adapter for Zmij C++ implementation, for float/double formatting.
+//
+// https://github.com/dtolnay/zmij
+//
+// Only supports floating point formatting with `UFBXW_ASCII_FLOAT_FORMAT_ROUND_TRIP`.
+//
+// In one C++ translation unit, do the following:
+//
+//     #include "path/to/ufbx_write.h"
+//     #include "path/to/zmij.h"
+//
+//     #define UFBXW_ZMIJ_IMPLEMENTATION
+//     #include "path/to/ufbxw_zmij.h"
+//
+// You can still use `ufbxw_zmij_setup()` from C.
+
+#include <stddef.h>
+
+#if !defined(ufbxw_zmij_abi)
+	#if defined(UFBXW_ZMIJ_STATIC)
+		#define ufbxw_zmij_abi static
+	#else
+		#define ufbxw_zmij_abi
+	#endif
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+// Setup float/double formatter callbacks to Zmij.
+//
+// NOTE: This only sets `format_float_fn` and `format_double_fn`, and will use default integer formatters.
+//
+// This call preserves `format_int_fn/format_float_fn()`, so you can call this after another adapter:
+//
+//     ufbxw_<formatter>_setup(&opts.ascii_formatter);
+//     ufbxw_zmij_setup(&opts.ascii_formatter);
+//
+ufbxw_zmij_abi void ufbxw_zmij_setup(struct ufbxw_ascii_formatter *formatter);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif
+
+#ifdef UFBXW_ZMIJ_IMPLEMENTATION
+#ifndef UFBXW_ZMIJ_H_IMPLEMENTED
+#define UFBXW_ZMIJ_H_IMPLEMENTED
+
+#if !defined(__cplusplus)
+	#error "ufbxw_zmij.h should be implemented in a C++ file, though it can be used in another C file"
+#endif
+
+#if !defined(UFBXW_VERSION)
+	#error "Please include ufbx_write.h before implementing ufbxw_zmij.h"
+#endif
+
+#if !defined(ZMIJ_H_)
+	#error "Please include zmij.h before implementing ufbxw_zmij.h"
+#endif
+
+#include <stdint.h>
+
+static size_t ufbxw_zmij_format_float(void *user, char *dst, size_t dst_size, const float *src, size_t src_count, ufbxw_ascii_float_format format)
+{
+	if (format != UFBXW_ASCII_FLOAT_FORMAT_ROUND_TRIP) return SIZE_MAX;
+
+	char *d = dst;
+	for (size_t i = 0; i < src_count; i++) {
+		d = zmij::write(d, (size_t)zmij::float_buffer_size, src[i]);
+		*d++ = ',';
+	}
+	return (size_t)(d - dst);
+}
+
+static size_t ufbxw_zmij_format_double(void *user, char *dst, size_t dst_size, const double *src, size_t src_count, ufbxw_ascii_float_format format)
+{
+	if (format != UFBXW_ASCII_FLOAT_FORMAT_ROUND_TRIP) return SIZE_MAX;
+
+	char *d = dst;
+	for (size_t i = 0; i < src_count; i++) {
+		d = zmij::write(d, (size_t)zmij::double_buffer_size, src[i]);
+		*d++ = ',';
+	}
+	return (size_t)(d - dst);
+}
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+ufbxw_zmij_abi void ufbxw_zmij_setup(struct ufbxw_ascii_formatter *formatter)
+{
+	formatter->format_float_fn = &ufbxw_zmij_format_float;
+	formatter->format_double_fn = &ufbxw_zmij_format_double;
+}
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif
+#endif

--- a/extra/ufbxw_zmij_c.h
+++ b/extra/ufbxw_zmij_c.h
@@ -60,6 +60,11 @@ ufbxw_zmij_c_abi void ufbxw_zmij_c_setup(struct ufbxw_ascii_formatter *formatter
 
 #include <stdint.h>
 
+#define ufbxw_zmij_static_assert(desc, cond) typedef char ufbxw_zmij_static_assert_##desc[(cond)?1:-1]
+
+ufbxw_zmij_static_assert(float_buffer_size, zmij_float_buffer_size <= UFBXW_ASCII_FORMAT_FLOAT_CHARS + UFBXW_ASCII_FORMAT_EXTRA_BUFFER_CHARS);
+ufbxw_zmij_static_assert(double_buffer_size, zmij_double_buffer_size <= UFBXW_ASCII_FORMAT_DOUBLE_CHARS + UFBXW_ASCII_FORMAT_EXTRA_BUFFER_CHARS);
+
 static size_t ufbxw_zmij_c_format_float(void *user, char *dst, size_t dst_size, const float *src, size_t src_count, ufbxw_ascii_float_format format)
 {
 	if (format != UFBXW_ASCII_FLOAT_FORMAT_ROUND_TRIP) return SIZE_MAX;

--- a/extra/ufbxw_zmij_c.h
+++ b/extra/ufbxw_zmij_c.h
@@ -1,0 +1,102 @@
+#ifndef UFBXW_ZMIJ_C_H_INCLUDED
+#define UFBXW_ZMIJ_C_H_INCLUDED
+
+// Adapter for Zmij C implementation, for float/double formatting.
+//
+// https://github.com/dtolnay/zmij
+//
+// Only supports floating point formatting with `UFBXW_ASCII_FLOAT_FORMAT_ROUND_TRIP`.
+//
+// In one translation unit, do the following:
+//
+//     #include "path/to/ufbx_write.h"
+//     #include "path/to/zmij-c.h"
+//
+//     #define UFBXW_ZMIJ_C_IMPLEMENTATION
+//     #include "path/to/ufbxw_zmij_c.h"
+
+#include <stddef.h>
+
+#if !defined(ufbxw_zmij_c_abi)
+	#if defined(UFBXW_ZMIJ_C_STATIC)
+		#define ufbxw_zmij_c_abi static
+	#else
+		#define ufbxw_zmij_c_abi
+	#endif
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+// Setup float/double formatter callbacks to Zmij.
+//
+// NOTE: This only sets `format_float_fn` and `format_double_fn`, and will use default integer formatters.
+//
+// This call preserves `format_int_fn/format_float_fn()`, so you can call this after another adapter:
+//
+//     ufbxw_<formatter>_setup(&opts.ascii_formatter);
+//     ufbxw_zmij_c_setup(&opts.ascii_formatter);
+//
+ufbxw_zmij_c_abi void ufbxw_zmij_c_setup(struct ufbxw_ascii_formatter *formatter);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif
+
+#ifdef UFBXW_ZMIJ_C_IMPLEMENTATION
+#ifndef UFBXW_ZMIJ_C_H_IMPLEMENTED
+#define UFBXW_ZMIJ_C_H_IMPLEMENTED
+
+#if !defined(UFBXW_VERSION)
+	#error "Please include ufbx_write.h before implementing ufbxw_zmij_c.h"
+#endif
+
+#if !defined(ZMIJ_C_H_)
+	#error "Please include zmij-c.h before implementing ufbxw_zmij_c.h"
+#endif
+
+#include <stdint.h>
+
+static size_t ufbxw_zmij_c_format_float(void *user, char *dst, size_t dst_size, const float *src, size_t src_count, ufbxw_ascii_float_format format)
+{
+	if (format != UFBXW_ASCII_FLOAT_FORMAT_ROUND_TRIP) return SIZE_MAX;
+
+	char *d = dst;
+	for (size_t i = 0; i < src_count; i++) {
+		d += zmij_write_float(d, zmij_float_buffer_size, src[i]);
+		*d++ = ',';
+	}
+	return (size_t)(d - dst);
+}
+
+static size_t ufbxw_zmij_c_format_double(void *user, char *dst, size_t dst_size, const double *src, size_t src_count, ufbxw_ascii_float_format format)
+{
+	if (format != UFBXW_ASCII_FLOAT_FORMAT_ROUND_TRIP) return SIZE_MAX;
+
+	char *d = dst;
+	for (size_t i = 0; i < src_count; i++) {
+		d += zmij_write_double(d, zmij_double_buffer_size, src[i]);
+		*d++ = ',';
+	}
+	return (size_t)(d - dst);
+}
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+ufbxw_zmij_c_abi void ufbxw_zmij_c_setup(struct ufbxw_ascii_formatter *formatter)
+{
+	formatter->format_float_fn = &ufbxw_zmij_c_format_float;
+	formatter->format_double_fn = &ufbxw_zmij_c_format_double;
+}
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif
+#endif

--- a/extra/ufbxw_zmij_c.h
+++ b/extra/ufbxw_zmij_c.h
@@ -3,7 +3,7 @@
 
 // Adapter for Zmij C implementation, for float/double formatting.
 //
-// https://github.com/dtolnay/zmij
+// https://github.com/vitaut/zmij
 //
 // Only supports floating point formatting with `UFBXW_ASCII_FLOAT_FORMAT_ROUND_TRIP`.
 //

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,10 @@ if(MSVC)
     set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} /Ob2")
 endif()
 
+if (MSVC)
+    add_compile_options(/MP)
+endif()
+
 target_sources(ufbx_write PRIVATE ${SRC_UFBX_WRITE})
 
 if(USE_ASAN OR USE_UBSAN)

--- a/test/compare_fbx/compare_fbx.cpp
+++ b/test/compare_fbx/compare_fbx.cpp
@@ -34,24 +34,34 @@ void format(char *&dst, char *end, bool value)
 	dst += snprintf(dst, end - dst, "%s", value ? "true" : "false");
 }
 
-void format(char *&dst, char *end, int32_t value)
+void format(char *&dst, char *end, int value)
 {
-	dst += snprintf(dst, end - dst, "%" PRIi32, value);
+	dst += snprintf(dst, end - dst, "%d", value);
 }
 
-void format(char *&dst, char *end, uint32_t value)
+void format(char *&dst, char *end, unsigned int value)
 {
-	dst += snprintf(dst, end - dst, "%" PRIu32, value);
+	dst += snprintf(dst, end - dst, "%u", value);
 }
 
-void format(char *&dst, char *end, int64_t value)
+void format(char *&dst, char *end, long value)
 {
-	dst += snprintf(dst, end - dst, "%" PRIi64, value);
+	dst += snprintf(dst, end - dst, "%ld", value);
 }
 
-void format(char *&dst, char *end, uint64_t value)
+void format(char *&dst, char *end, unsigned long value)
 {
-	dst += snprintf(dst, end - dst, "%" PRIu64, value);
+	dst += snprintf(dst, end - dst, "%lu", value);
+}
+
+void format(char *&dst, char *end, long long value)
+{
+	dst += snprintf(dst, end - dst, "%lld", value);
+}
+
+void format(char *&dst, char *end, unsigned long long value)
+{
+	dst += snprintf(dst, end - dst, "%llu", value);
 }
 
 void format(char *&dst, char *end, double value)

--- a/test/extra/CMakeLists.txt
+++ b/test/extra/CMakeLists.txt
@@ -6,6 +6,7 @@ option(USE_LIBDEFLATE "Enable libdeflate" ON)
 option(USE_ZLIB "Enable Zlib" ON)
 option(USE_FMTLIB "Enable fmtlib" ON)
 option(USE_TO_CHARS "Enable to_chars" ON)
+option(USE_ZMIJ "Enable Zmij" ON)
 option(USE_CPP_THREADS "Enable C++ threads" ON)
 
 set(SRC_EXTRA "")
@@ -75,6 +76,42 @@ if(USE_TO_CHARS)
     target_compile_definitions(ufbxw_extra PUBLIC UFBXWT_HAS_TO_CHARS=1)
 
     list(APPEND SRC_EXTRA "../../extra/ufbxw_to_chars.h" "ufbxw_to_chars.cpp")
+endif()
+
+if(USE_ZMIJ)
+    FetchContent_Populate(
+        zmij
+        GIT_REPOSITORY "https://github.com/vitaut/zmij.git"
+        GIT_TAG main
+    )
+
+    add_library(zmij STATIC EXCLUDE_FROM_ALL
+        "${zmij_SOURCE_DIR}/zmij.cc"
+        "${zmij_SOURCE_DIR}/zmij.h"
+    )
+    target_compile_features(zmij PRIVATE cxx_std_14)
+    target_include_directories(zmij PUBLIC "${zmij_SOURCE_DIR}")
+    if(MSVC)
+        # MSVC fails to resolve `float_traits::is_iec559` without `/permissive-`
+        # warning C4804: '-': unsafe use of type 'bool' in operation
+        target_compile_options(zmij PRIVATE /permissive- /wd4804)
+    endif()
+
+    add_library(zmij_c STATIC EXCLUDE_FROM_ALL
+        "${zmij_SOURCE_DIR}/zmij.c"
+        "${zmij_SOURCE_DIR}/zmij-c.h"
+    )
+    target_include_directories(zmij_c PUBLIC "${zmij_SOURCE_DIR}")
+
+    target_link_libraries(ufbxw_extra PRIVATE zmij zmij_c)
+    target_compile_definitions(ufbxw_extra PUBLIC UFBXWT_HAS_ZMIJ=1)
+
+    list(APPEND SRC_EXTRA
+        "../../extra/ufbxw_zmij.h"
+        "../../extra/ufbxw_zmij_c.h"
+        "ufbxw_zmij.cpp"
+        "ufbxw_zmij_c.c"
+    )
 endif()
 
 if(USE_CPP_THREADS)

--- a/test/extra/ufbxw_zmij.cpp
+++ b/test/extra/ufbxw_zmij.cpp
@@ -1,0 +1,6 @@
+#include "../../ufbx_write.h"
+
+#include "zmij.h"
+
+#define UFBXW_ZMIJ_IMPLEMENTATION
+#include "../../extra/ufbxw_zmij.h"

--- a/test/extra/ufbxw_zmij_c.c
+++ b/test/extra/ufbxw_zmij_c.c
@@ -1,0 +1,6 @@
+#include "../../ufbx_write.h"
+
+#include "zmij-c.h"
+
+#define UFBXW_ZMIJ_C_IMPLEMENTATION
+#include "../../extra/ufbxw_zmij_c.h"

--- a/test/test/CMakeLists.txt
+++ b/test/test/CMakeLists.txt
@@ -3,6 +3,9 @@ add_executable(ufbxw_test)
 file(GLOB SRC_TEST *.c *.h)
 
 target_link_libraries(ufbxw_test PRIVATE ufbx_write ufbx ufbxw_extra ufbxwt_util)
-target_compile_options(ufbxw_test PRIVATE -Wno-format-truncation)
+
+if (NOT MSVC)
+    target_compile_options(ufbxw_test PRIVATE -Wno-format-truncation)
+endif()
 
 target_sources(ufbxw_test PRIVATE ${SRC_TEST})

--- a/test/test/test_ascii.h
+++ b/test/test/test_ascii.h
@@ -74,6 +74,12 @@ static void ufbxwt_ascii_format_test(const char *name, ufbxw_scene *scene, const
 
 					ufbxw_error save_error;
 					bool save_ok = ufbxw_save_stream(scene, &ws, &save_opts, &save_error);
+
+					if (!ufbxwt_ascii_format_supports_float_format(ascii_impl, save_opts.ascii_float_format)) {
+						ufbxwt_assert(!save_ok);
+						ufbxwt_assert(save_error.type == UFBXW_ERROR_ASCII_FORMAT);
+						continue;
+					}
 					if (save_error.type != UFBXW_ERROR_NONE) {
 						ufbxwt_log_error(&save_error);
 					}

--- a/test/util/im_arg.h
+++ b/test/util/im_arg.h
@@ -684,6 +684,7 @@ bool im_arg_ctx(im_arg_context *ctx, const char *fmt, const char *description)
 			case IM_ARG__COUNT_ANY: suffix = "*"; break;
 			case IM_ARG__COUNT_ZERO_OR_ONE: suffix = "?"; break;
 			case IM_ARG__COUNT_ONE_OR_MORE: suffix = "+"; break;
+			default: break;
 			}
 			if (do_print) {
 				printf("%s%.*s%s", prefix, (int)arg->length, fmt + arg->offset, suffix);

--- a/test/util/ufbxwt_util.c
+++ b/test/util/ufbxwt_util.c
@@ -154,9 +154,12 @@ bool ufbxwt_thread_setup(ufbxw_thread_sync *sync, ufbxw_thread_pool *pool, ufbxw
 		return true;
 
 	case UFBXWT_THREAD_IMPL_CPP_THREADS:
-		ufbxw_cpp_threads_setup_sync(sync);
-		ufbxw_cpp_threads_setup_pool(pool);
-		return true;
+		#if UFBXWT_HAS_CPP_THREADS
+			ufbxw_cpp_threads_setup_sync(sync);
+			ufbxw_cpp_threads_setup_pool(pool);
+			return true;
+		#endif
+		return false;
 
 	default:
 		ufbxwt_assert(false);

--- a/test/util/ufbxwt_util.c
+++ b/test/util/ufbxwt_util.c
@@ -16,6 +16,11 @@
 	#include "../../extra/ufbxw_to_chars.h"
 #endif
 
+#ifdef UFBXWT_HAS_ZMIJ
+	#include "../../extra/ufbxw_zmij.h"
+	#include "../../extra/ufbxw_zmij_c.h"
+#endif
+
 #ifdef UFBXWT_HAS_CPP_THREADS
 	#include "../../extra/ufbxw_cpp_threads.h"
 #endif
@@ -91,6 +96,20 @@ bool ufbxwt_ascii_format_setup(ufbxw_ascii_formatter *formatter, ufbxwt_ascii_fo
 		#endif
 		return false;
 
+	case UFBXWT_ASCII_FORMAT_IMPL_ZMIJ:
+		#if UFBXWT_HAS_ZMIJ
+			ufbxw_zmij_setup(formatter);
+			return true;
+		#endif
+		return false;
+
+	case UFBXWT_ASCII_FORMAT_IMPL_ZMIJ_C:
+		#if UFBXWT_HAS_ZMIJ
+			ufbxw_zmij_c_setup(formatter);
+			return true;
+		#endif
+		return false;
+
 	default:
 		ufbxwt_assert(false);
 		break;
@@ -104,8 +123,28 @@ const char *ufbxwt_ascii_format_name(ufbxwt_ascii_format_impl impl)
 	case UFBXWT_ASCII_FORMAT_IMPL_DEFAULT: return "default";
 	case UFBXWT_ASCII_FORMAT_IMPL_FMTLIB: return "fmtlib";
 	case UFBXWT_ASCII_FORMAT_IMPL_TO_CHARS: return "to_chars";
+	case UFBXWT_ASCII_FORMAT_IMPL_ZMIJ: return "zmij";
+	case UFBXWT_ASCII_FORMAT_IMPL_ZMIJ_C: return "zmij_c";
 	default: return "";
 	}
+}
+
+bool ufbxwt_ascii_format_supports_float_format(ufbxwt_ascii_format_impl impl, ufbxw_ascii_float_format format)
+{
+	switch (impl) {
+	case UFBXWT_ASCII_FORMAT_IMPL_DEFAULT: return true;
+	case UFBXWT_ASCII_FORMAT_IMPL_FMTLIB: return true;
+	case UFBXWT_ASCII_FORMAT_IMPL_TO_CHARS: return true;
+
+	case UFBXWT_ASCII_FORMAT_IMPL_ZMIJ:
+	case UFBXWT_ASCII_FORMAT_IMPL_ZMIJ_C:
+		return format == UFBXW_ASCII_FLOAT_FORMAT_ROUND_TRIP;
+
+	default:
+		ufbxwt_assert(false);
+		break;
+	}
+	return false;
 }
 
 bool ufbxwt_thread_setup(ufbxw_thread_sync *sync, ufbxw_thread_pool *pool, ufbxwt_thread_impl impl)
@@ -134,4 +173,3 @@ const char *ufbxwt_thread_impl_name(ufbxwt_thread_impl impl)
 	default: return "";
 	}
 }
-

--- a/test/util/ufbxwt_util.h
+++ b/test/util/ufbxwt_util.h
@@ -14,6 +14,8 @@ typedef enum {
 	UFBXWT_ASCII_FORMAT_IMPL_DEFAULT,
 	UFBXWT_ASCII_FORMAT_IMPL_FMTLIB,
 	UFBXWT_ASCII_FORMAT_IMPL_TO_CHARS,
+	UFBXWT_ASCII_FORMAT_IMPL_ZMIJ,
+	UFBXWT_ASCII_FORMAT_IMPL_ZMIJ_C,
 
 	UFBXWT_ASCII_FORMAT_IMPL_COUNT,
 } ufbxwt_ascii_format_impl;
@@ -32,6 +34,7 @@ const char *ufbxwt_deflate_impl_name(ufbxwt_deflate_impl impl);
 
 bool ufbxwt_ascii_format_setup(ufbxw_ascii_formatter *formatter, ufbxwt_ascii_format_impl impl);
 const char *ufbxwt_ascii_format_name(ufbxwt_ascii_format_impl impl);
+bool ufbxwt_ascii_format_supports_float_format(ufbxwt_ascii_format_impl impl, ufbxw_ascii_float_format format);
 
 bool ufbxwt_thread_setup(ufbxw_thread_sync *sync, ufbxw_thread_pool *pool, ufbxwt_thread_impl impl);
 const char *ufbxwt_thread_impl_name(ufbxwt_thread_impl impl);

--- a/ufbx_write.c
+++ b/ufbx_write.c
@@ -8222,6 +8222,8 @@ UFBXWI_LIST_TYPE(ufbxwi_write_buffer_ptr_list, ufbxwi_write_buffer*);
 UFBXWI_LIST_TYPE(ufbxwi_write_chunk_ptr_list, ufbxwi_write_chunk*);
 UFBXWI_LIST_TYPE(ufbxwi_write_reloc_list, ufbxwi_write_reloc);
 
+#define UFBXWI_WRITE_SMALL_MAX_BYTES 256
+
 typedef struct {
 	ufbxwi_allocator *ator;
 	ufbxwi_error *error;
@@ -8235,6 +8237,7 @@ typedef struct {
 	char *buffer_pos;
 	char *buffer_end;
 	size_t direct_write_size;
+	bool buffer_failed;
 
 	ufbxwi_write_chunk *current_chunk;
 	ufbxwi_write_chunk_ptr_list chunks;
@@ -8253,6 +8256,9 @@ typedef struct {
 
 	ufbxwi_mutex buffer_mutex;
 	ufbxwi_write_buffer_ptr_list free_buffers;
+
+	// Temporary small reserve buffer to write to, if we encounter a fatal error
+	char fatal_small_buffer[UFBXWI_WRITE_SMALL_MAX_BYTES];
 
 } ufbxwi_write_queue;
 
@@ -8568,34 +8574,45 @@ static ufbxwi_noinline bool ufbxwi_write_queue_finish(ufbxwi_write_queue *wq)
 
 static ufbxwi_noinline char *ufbxwi_queue_write_reserve_slow(ufbxwi_write_queue *wq, size_t length)
 {
+	if (wq->buffer_failed) return NULL;
+
 	ufbxwi_check(ufbxwi_write_queue_flush(wq, length), NULL);
 
 	return wq->buffer_pos;
 }
 
+static ufbxwi_noinline char *ufbxwi_queue_write_reserve_small_slow(ufbxwi_write_queue *wq, size_t length)
+{
+	char *dst = ufbxwi_queue_write_reserve_slow(wq, length);
+	return dst ? dst : wq->fatal_small_buffer;
+}
+
 static ufbxwi_forceinline char *ufbxwi_queue_write_reserve_small(ufbxwi_write_queue *wq, size_t length)
 {
-	ufbxwi_dev_assert(length <= 256);
+	ufbxwi_dev_assert(length <= UFBXWI_WRITE_SMALL_MAX_BYTES);
 
 	char *dst = wq->buffer_pos;
 	size_t left = ufbxwi_to_size(wq->buffer_end - dst);
 	if (left >= length) {
 		return wq->buffer_pos;
 	} else {
-		return ufbxwi_queue_write_reserve_slow(wq, length);
+		return ufbxwi_queue_write_reserve_small_slow(wq, length);
 	}
 }
 
 static ufbxwi_mutable_void_span ufbxwi_queue_write_reserve_at_least(ufbxwi_write_queue *wq, size_t length)
 {
+	ufbxwi_mutable_void_span span = { 0 };
+	if (wq->buffer_failed) return span;
+
 	char *dst = wq->buffer_pos;
 	size_t left = ufbxwi_to_size(wq->buffer_end - dst);
-	ufbxwi_mutable_void_span span;
 	if (left >= length) {
 		span.data = wq->buffer_pos;
 		span.count = left;
 	} else {
 		span.data = ufbxwi_queue_write_reserve_slow(wq, length);
+		if (!span.data) return span;
 		span.count = ufbxwi_to_size(wq->buffer_end - (char*)span.data);
 	}
 	return span;
@@ -8603,18 +8620,22 @@ static ufbxwi_mutable_void_span ufbxwi_queue_write_reserve_at_least(ufbxwi_write
 
 static ufbxwi_forceinline void ufbxwi_queue_write_commit(ufbxwi_write_queue *wq, size_t length)
 {
+	if (wq->buffer_failed) return;
+
 	ufbxw_assert(length <= ufbxwi_to_size(wq->buffer_end - wq->buffer_pos));
 	wq->buffer_pos += length;
 }
 
 static ufbxwi_mutable_void_span ufbxwi_queue_write_reserve_at_least_in_chunk(ufbxwi_write_queue *wq, ufbxwi_write_chunk *chunk, size_t length)
 {
+	ufbxwi_mutable_void_span result = { 0 };
+	if (wq->buffer_failed) return result;
+
 	if (chunk == NULL) {
 		return ufbxwi_queue_write_reserve_at_least(wq, length);
 	} else {
 		ufbxwi_write_chunk_part *const last_part = chunk->last_part;
 		ufbxwi_write_chunk_part *part;
-		ufbxwi_mutable_void_span result = { 0 };
 		if (last_part == NULL) {
 			part = &chunk->data;
 		} else {
@@ -8639,6 +8660,8 @@ static ufbxwi_mutable_void_span ufbxwi_queue_write_reserve_at_least_in_chunk(ufb
 
 static ufbxwi_forceinline void ufbxwi_queue_write_commit_in_chunk(ufbxwi_write_queue *wq, ufbxwi_write_chunk *chunk, size_t length)
 {
+	if (wq->buffer_failed) return;
+
 	if (chunk == NULL) {
 		ufbxwi_queue_write_commit(wq, length);
 	} else {
@@ -8652,7 +8675,7 @@ static ufbxwi_forceinline void ufbxwi_queue_write_commit_in_chunk(ufbxwi_write_q
 
 static ufbxwi_noinline bool ufbxwi_queue_write_slow(ufbxwi_write_queue *wq, const void *data, size_t length)
 {
-	if (ufbxwi_is_fatal(wq->error)) return false;
+	if (wq->buffer_failed) return false;
 
 	if (length >= wq->direct_write_size && wq->current_chunk->has_file_offset) {
 		// If we are doing a large write and know where we are writing, just write it directly to the file.
@@ -8972,7 +8995,7 @@ static void ufbxwi_ascii_comment(ufbxwi_save_context *sc, const char *fmt, va_li
 {
 	// TODO: More rigorous
 	// TODO: Sanitize \n's and other special characters
-	size_t max_length = 256;
+	size_t max_length = UFBXWI_WRITE_SMALL_MAX_BYTES;
 	char *dst = ufbxwi_write_reserve_small(sc, max_length);
 
 	int len = vsnprintf(dst, max_length, fmt, args);
@@ -9001,6 +9024,25 @@ static void ufbxwi_ascii_dom_string(ufbxwi_save_context *sc, const char *str, si
 	ufbxwi_write(sc, "\"", 1);
 }
 
+static ufbxwi_noinline void ufbxwi_ascii_check_format_fail(ufbxwi_error *error, size_t dst_size, size_t result_size)
+{
+	if (result_size == 0 || result_size == SIZE_MAX) {
+		ufbxwi_failf(error, UFBXW_ERROR_ASCII_FORMAT, "ASCII format failed");
+	} else {
+		ufbxwi_failf(error, UFBXW_ERROR_ASCII_FORMAT, "ASCII format overflow: %zu/%zu bytes", result_size, dst_size);
+	}
+}
+
+static ufbxwi_forceinline bool ufbxwi_ascii_check_format_result(ufbxwi_error *error, size_t dst_size, size_t result_size)
+{
+	if (result_size > 0 && result_size <= dst_size) {
+		return true;
+	} else {
+		ufbxwi_ascii_check_format_fail(error, dst_size, result_size);
+		return false;
+	}
+}
+
 static void ufbxwi_ascii_dom_write(ufbxwi_save_context *sc, const char *tag, const char *fmt, va_list args, bool open)
 {
 	ufbxwi_ascii_indent(sc);
@@ -9020,47 +9062,55 @@ static void ufbxwi_ascii_dom_write(ufbxwi_save_context *sc, const char *tag, con
 
 		switch (f) {
 		case 'I': {
-			char *dst = ufbxwi_write_reserve_small(sc, 128);
 			int32_t src[4];
 			size_t src_count = 1;
 			src[0] = va_arg(args, int32_t);
 			for (; pf[1] == 'I' && src_count < 4; src_count++, pf++) {
 				src[src_count] = va_arg(args, int32_t);
 			}
-			size_t len = sc->opts.ascii_formatter.format_int_fn(sc->opts.ascii_formatter.user, dst, 128, src, src_count);
+			size_t dst_size = src_count * UFBXW_ASCII_FORMAT_INT_CHARS + UFBXW_ASCII_FORMAT_EXTRA_BUFFER_CHARS;
+			char *dst = ufbxwi_write_reserve_small(sc, dst_size);
+			size_t len = sc->opts.ascii_formatter.format_int_fn(sc->opts.ascii_formatter.user, dst, dst_size, src, src_count);
+			ufbxwi_check(ufbxwi_ascii_check_format_result(&sc->error, dst_size, len));
 			ufbxwi_write_commit(sc, (size_t)len - 1);
 		} break;
 		case 'L': {
-			char *dst = ufbxwi_write_reserve_small(sc, 128);
 			int64_t src[4];
 			size_t src_count = 1;
 			src[0] = va_arg(args, int64_t);
 			for (; pf[1] == 'L' && src_count < 4; src_count++, pf++) {
 				src[src_count] = va_arg(args, int64_t);
 			}
-			size_t len = sc->opts.ascii_formatter.format_long_fn(sc->opts.ascii_formatter.user, dst, 128, src, src_count);
+			size_t dst_size = src_count * UFBXW_ASCII_FORMAT_LONG_CHARS + UFBXW_ASCII_FORMAT_EXTRA_BUFFER_CHARS;
+			char *dst = ufbxwi_write_reserve_small(sc, dst_size);
+			size_t len = sc->opts.ascii_formatter.format_long_fn(sc->opts.ascii_formatter.user, dst, dst_size, src, src_count);
+			ufbxwi_check(ufbxwi_ascii_check_format_result(&sc->error, dst_size, len));
 			ufbxwi_write_commit(sc, (size_t)len - 1);
 		} break;
 		case 'F': {
-			char *dst = ufbxwi_write_reserve_small(sc, 128);
 			float src[4];
 			size_t src_count = 1;
 			src[0] = (float)va_arg(args, double);
 			for (; pf[1] == 'F' && src_count < 4; src_count++, pf++) {
 				src[src_count] = (float)va_arg(args, double);
 			}
-			size_t len = sc->opts.ascii_formatter.format_float_fn(sc->opts.ascii_formatter.user, dst, 128, src, src_count, sc->opts.ascii_float_format);
+			size_t dst_size = src_count * UFBXW_ASCII_FORMAT_FLOAT_CHARS + UFBXW_ASCII_FORMAT_EXTRA_BUFFER_CHARS;
+			char *dst = ufbxwi_write_reserve_small(sc, dst_size);
+			size_t len = sc->opts.ascii_formatter.format_float_fn(sc->opts.ascii_formatter.user, dst, dst_size, src, src_count, sc->opts.ascii_float_format);
+			ufbxwi_check(ufbxwi_ascii_check_format_result(&sc->error, dst_size, len));
 			ufbxwi_write_commit(sc, (size_t)len - 1);
 		} break;
 		case 'D': {
-			char *dst = ufbxwi_write_reserve_small(sc, 128);
 			double src[4];
 			size_t src_count = 1;
 			src[0] = va_arg(args, double);
 			for (; pf[1] == 'D' && src_count < 4; src_count++, pf++) {
 				src[src_count] = va_arg(args, double);
 			}
-			size_t len = sc->opts.ascii_formatter.format_double_fn(sc->opts.ascii_formatter.user, dst, 128, src, src_count, sc->opts.ascii_float_format);
+			size_t dst_size = src_count * UFBXW_ASCII_FORMAT_DOUBLE_CHARS + UFBXW_ASCII_FORMAT_EXTRA_BUFFER_CHARS;
+			char *dst = ufbxwi_write_reserve_small(sc, dst_size);
+			size_t len = sc->opts.ascii_formatter.format_double_fn(sc->opts.ascii_formatter.user, dst, dst_size, src, src_count, sc->opts.ascii_float_format);
+			ufbxwi_check(ufbxwi_ascii_check_format_result(&sc->error, dst_size, len));
 			ufbxwi_write_commit(sc, (size_t)len - 1);
 		} break;
 		case 'C': {
@@ -9132,7 +9182,15 @@ static ufbxwi_noinline bool ufbxwi_ascii_write_array_data(ufbxwi_save_thread_con
 			size_t src_count = ufbxwi_min_sz(span_scalars - begin, line_scalars);
 			const void *src = (const char*)span.data + begin * scalar_size;
 
-			size_t dst_size = src_count * 28 + 1;
+			size_t elem_chars = 0;
+			switch (scalar_type) {
+			case UFBXWI_BUFFER_TYPE_INT: elem_chars = UFBXW_ASCII_FORMAT_INT_CHARS; break;
+			case UFBXWI_BUFFER_TYPE_LONG: elem_chars = UFBXW_ASCII_FORMAT_LONG_CHARS; break;
+			case UFBXWI_BUFFER_TYPE_FLOAT: elem_chars = UFBXW_ASCII_FORMAT_FLOAT_CHARS; break;
+			case UFBXWI_BUFFER_TYPE_REAL: elem_chars = UFBXW_ASCII_FORMAT_DOUBLE_CHARS; break;
+			default: ufbxwi_unreachable("bad scalar type");
+			}
+			size_t dst_size = src_count * elem_chars + UFBXW_ASCII_FORMAT_EXTRA_BUFFER_CHARS;
 
 			if (ufbxwi_to_size(dst_end - dst_pos) < dst_size) {
 				if (dst_pos > dst_start) {
@@ -9164,10 +9222,7 @@ static ufbxwi_noinline bool ufbxwi_ascii_write_array_data(ufbxwi_save_thread_con
 				ufbxwi_unreachable("bad scalar type");
 			}
 
-			if (result_length == 0 || result_length == SIZE_MAX) {
-				ufbxwi_fail(tc->error, UFBXW_ERROR_ASCII_FORMAT, "failed to format ASCII numbers");
-				return false;
-			}
+			ufbxwi_check(ufbxwi_ascii_check_format_result(tc->error, dst_size, result_length), false);
 
 			scalars_left -= src_count;
 			begin += src_count;
@@ -10992,10 +11047,10 @@ static void ufbxwi_mark_save_context_failed(ufbxwi_save_context *sc)
 {
 	ufbxwi_mark_buffers_failed(&sc->buffers);
 
-	// TODO(wq): Make this better
-	sc->write_queue.buffer_begin = NULL;
-	sc->write_queue.buffer_pos = NULL;
-	sc->write_queue.buffer_end = NULL;
+	sc->write_queue.buffer_begin = (char*)ufbxwi_zero_size_buffer;
+	sc->write_queue.buffer_pos = (char*)ufbxwi_zero_size_buffer;
+	sc->write_queue.buffer_end = (char*)ufbxwi_zero_size_buffer;
+	sc->write_queue.buffer_failed = true;
 }
 
 static void ufbxwi_save_fatal(void *user, ufbxwi_error *error)

--- a/ufbx_write.h
+++ b/ufbx_write.h
@@ -1295,6 +1295,16 @@ typedef struct ufbxw_deflate {
 
 // -- ASCII formatting
 
+// Number of characters reserved for formatting ASCII, per element
+// Allow space for maximum length, comma, and optional space.
+#define UFBXW_ASCII_FORMAT_INT_CHARS 13
+#define UFBXW_ASCII_FORMAT_LONG_CHARS 22
+#define UFBXW_ASCII_FORMAT_FLOAT_CHARS 20
+#define UFBXW_ASCII_FORMAT_DOUBLE_CHARS 28
+
+// Number of additional bytes in the end of the buffer, in case the formatter needs scratch space.
+#define UFBXW_ASCII_FORMAT_EXTRA_BUFFER_CHARS 64
+
 // TODO: Should round trip be default?
 typedef enum ufbxw_ascii_float_format {
 	// Fixed-precision formatting, matching what the FBX SDK outputs.


### PR DESCRIPTION
Added Zmij for ASCII float/double formatting.

Turns out that this finally triggered the fatal ASCII formatting path, so finally made `ufbxwi_write_queue` robust against failure.

TODO: Proper testing for failing write/alloc at any possible point, like ufbx.